### PR TITLE
Move Dora Zhang to alumni

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -77,12 +77,6 @@
   # Source: https://www.architecture.cmu.edu/profiles/cassie-li
   headshot: "/assets/headshots/cassie-li.jpg"
 
-- first: Leyi (Dora)
-  last: Zhang
-  role: M.S. Student
-  alum: false
-  email: "leyiz@andrew.cmu.edu"
-  headshot: "https://raw.githubusercontent.com/cmudrc/cmudrc.github.io/main/assets/headshots/dzhang.jpeg"
 - first: Samuel
   last: Lapp
   role: PhD Student @ University of Pittsburgh
@@ -340,6 +334,13 @@
   year: 2024
   alum: true
   role: Analyst @ Accenture
+
+- first: Leyi (Dora)
+  last: Zhang
+  degree: MS
+  year: 2024
+  alum: true
+  role: Product Designer @ WinWin Labs
 
 - first: Vasvi
   last: Agarwal


### PR DESCRIPTION
## What changed

- Moved Leyi (Dora) Zhang from the current-member grid to the alumni list.
- Recorded her as MS 2024 and Product Designer at WinWin Labs.

## Why

The current lab roster still listed Dora as an M.S. student after she became an alum.

## Impact

The team page now shows 11 current members and 41 alumni. Dora remains discoverable in the alumni list rather than being deleted from the site.

## Validation

- Parsed `_data/members.yml` and confirmed Dora appears only as an alum
- Confirmed roster counts: 11 current members, 41 alumni
- `bundle exec jekyll build`
- Confirmed the generated team page renders `Leyi (Dora) Zhang, MS 2024, now Product Designer @ WinWin Labs`