### PR TITLE
Correct Scotty and Martha alumni details

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -355,11 +355,13 @@
   degree: PhD
   year: 2026
   alum: true
+  role: Computational Geometry Senior Software Engineer @ Re:Build Manufacturing
 
 - first: Scotty
   last: McGee
+  degree: PhD
+  year: 2026
   alum: true
-  role: Ph.D. Candidate @ CMU
 
 - first: Kai
   last: Herchenroether


### PR DESCRIPTION
## What changed

- add Scotty McGee’s PhD degree and 2026 graduation year
- remove Scotty’s former CMU candidate position
- add Martha Baldwin’s current role at Re:Build Manufacturing

## Why

The roster moved Scotty to alumni without her completed degree metadata and retained a no-longer-current candidate role. Martha’s alumni entry was missing her current position.

## Impact

The Team page now renders:

- Martha Baldwin, PhD 2026, now Computational Geometry Senior Software Engineer @ Re:Build Manufacturing
- Scotty McGee, PhD 2026

## Validation

- parsed `_data/members.yml` and asserted the two roster records
- ran a production Jekyll build
- checked the generated Team HTML
- rendered `/team/` in Chromium and visually verified the alumni list