### PR TITLE
Refresh lab website content and research catalogs

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -2,8 +2,13 @@
   last: McComb
   role: Director
   year: 1000000
-  headshot: "https://cmccomb.com/assets/images/headshot_optimized_square.jpg"
+  headshot: "/assets/headshots/McComb.jpeg"
   email: "ccm@cmu.edu"
+  linkedin: "https://www.linkedin.com/in/ccmcc"
+  keywords:
+    - Human–AI teaming
+    - Computational design
+    - Sociotechnical systems
   alum: false
 
 - first: Wenzhuo
@@ -11,35 +16,60 @@
   role: Ph.D. Student
   alum: false
   email: "wxu2@andrew.cmu.edu"
-  headshot: "https://raw.githubusercontent.com/cmudrc/cmudrc.github.io/main/assets/headshots/xu.jpeg"
+  headshot: "/assets/headshots/xu.jpeg"
+  linkedin: "https://www.linkedin.com/in/wenzhuo-xu-174592110"
+  keywords:
+    - Scientific machine learning
+    - Neural operators
+    - Engineering simulation
   
 - first: Aslan
   last: Noorghasemi
   role: Ph.D. Student
   alum: false
-  headshot: "https://raw.githubusercontent.com/cmudrc/cmudrc.github.io/main/assets/headshots/noorghasemi.jpeg"
+  headshot: "/assets/headshots/noorghasemi.jpeg"
   email: "aslann@cmu.edu"
+  linkedin: "https://www.linkedin.com/in/aslan-ng"
+  keywords:
+    - Agent-based modeling
+    - Community resilience
+    - Sociotechnical systems
   
 - first: Zeda
   last: Xu
   role: Ph.D. Student
   alum: false
-  headshot: "https://raw.githubusercontent.com/cmudrc/cmudrc.github.io/main/assets/headshots/zxu.jpeg"
+  headshot: "/assets/headshots/zxu.jpeg"
   email: "zedax@cmu.edu"
+  linkedin: "https://www.linkedin.com/in/zeda-xu"
+  keywords:
+    - Human–AI collaboration
+    - Design representation
+    - Shared understanding
   
 - first: Jessica
   last: Ezemba
   role: Ph.D. Student
   alum: false
-  headshot: "https://raw.githubusercontent.com/cmudrc/cmudrc.github.io/main/assets/headshots/ezemba.jpeg"
+  headshot: "/assets/headshots/ezemba.jpeg"
   email: "jezemba@andrew.cmu.edu"
+  linkedin: "https://www.linkedin.com/in/jessicaezemba"
+  keywords:
+    - Engineering AI evaluation
+    - Vision-language models
+    - Simulation surrogates
 
 - first: Chan-Eui
   last: Song
   role: Ph.D. Student
   alum: false
-  headshot: "https://raw.githubusercontent.com/cmudrc/cmudrc.github.io/main/assets/headshots/song.jpg"
+  headshot: "/assets/headshots/song.jpg"
   email: "chaneuis@andrew.cmu.edu"
+  linkedin: "https://www.linkedin.com/in/chan-eui-song-29a717238"
+  keywords:
+    - Vehicle electrification
+    - Energy systems
+    - Agentic engineering
 
 - first: George
   last: Tang
@@ -47,6 +77,11 @@
   alum: false
   # Source: https://aero.umd.edu/undergraduates/aeros-scholars
   headshot: "/assets/headshots/george-tang.jpg"
+  linkedin: "https://www.linkedin.com/in/george-tang-85024a19b"
+  keywords:
+    - Aerospace systems
+    - Computational mechanics
+    - Engineering education
 
 - first: Junlin
   last: Zhou
@@ -55,6 +90,11 @@
   # Profile: https://www.linkedin.com/in/junlin-zhou-b1596a293
   # Headshot source: https://www.cmu.edu/cit/veg/people/current-photos/jzhou.jpg
   headshot: "/assets/headshots/junlin-zhou.jpg"
+  linkedin: "https://www.linkedin.com/in/junlin-zhou-b1596a293"
+  keywords:
+    - EV charging
+    - Energy systems
+    - Infrastructure planning
 
 - first: Mayank
   last: Dixit
@@ -62,6 +102,11 @@
   alum: false
   # Source: https://engineering.cmu.edu/estp/directory/index.html
   headshot: "/assets/headshots/mayank-dixit.jpg"
+  linkedin: "https://www.linkedin.com/in/mayank-dixit-max007"
+  keywords:
+    - Aircraft analysis
+    - Agentic engineering
+    - Energy systems
 
 - first: Mary Manru
   last: Zhang
@@ -69,6 +114,11 @@
   alum: false
   # Source: https://www.scifilab.org/people
   headshot: "/assets/headshots/mary-manru-zhang.jpg"
+  linkedin: "https://www.linkedin.com/in/mary-manru-zhang-88221b154"
+  keywords:
+    - Bio-inspired design
+    - Generative design
+    - Human–AI collaboration
 
 - first: Cassie
   last: Li
@@ -77,6 +127,11 @@
   email: "cassieli@andrew.cmu.edu"
   # Source: https://www.architecture.cmu.edu/profiles/cassie-li
   headshot: "/assets/headshots/cassie-li.jpg"
+  linkedin: "https://www.linkedin.com/in/kexin-cassie-li"
+  keywords:
+    - Computational design
+    - Architecture
+    - Human–AI interaction
 
 - first: Samuel
   last: Lapp
@@ -106,8 +161,8 @@
   degree: MS
   alum: true
 
-- first: Mohammad
-  last: Alzayed
+- first: Mohammad AlSager
+  last: AlZayed
   role: Assistant Professor @ Kuwait University
   year: 2020
   degree: PhD
@@ -122,10 +177,10 @@
   
 - first: Akash
   last: Agrawal
-  year: 2021
-  degree: MS
+  year: 2024
+  degree: MS 2021; PhD
   alum: true
-  role: PhD student @ CMU
+  role: R&D Engineer II @ Ansys
   
 - first: Nicholas
   last: Holowsko
@@ -136,7 +191,7 @@
 
 - first: Harshika
   last: Singh
-  role: UX Researcher
+  role: Business Data Analyst @ Caterpillar
   year: 2021
   degree: PhD
   alum: true
@@ -185,28 +240,28 @@
   
 - first: Binyang
   last: Song
-  role: Postdoctoral Researcher @ MIT
+  role: Assistant Professor @ Nanyang Technological University
   year: 2021
   degree: Postdoc
   alum: true
 
 - first: Ayush
   last: Raina
-  role: Senior ML Researcher @ Playstation
+  role: Senior ML Researcher @ PlayStation
   year: 2022
   degree: PhD
   alum: true
   
 - first: Glen
   last: Williams
-  role: Principal Scientist @ Re:Build Manufacturing
+  role: Director of Artificial Intelligence @ Re:Build Manufacturing
   year: 2022
   degree: PhD
   alum: true
   
 - first: Hannah
   last: Nolte
-  role: Senior Research Scientist @ MITRE
+  role: Lead Human-Centered Systems Engineer @ MITRE
   year: 2022
   degree: PhD
   alum: true
@@ -227,13 +282,13 @@
 - first: Malena
   last: Agyemang
   year: 2022
-  role: Research Staff @ IDA
+  role: Staff Researcher @ Institute for Defense Analyses
   alum: true
   degree: Postdoc
 
 - first: Ambrosio
-  last: Valencia 
-  role: Postdoctoral Researcher @ The Roux Institute
+  last: Valencia-Romero
+  role: Assistant Professor @ Old Dominion University
   year: 2022
   alum: true
   degree: Postdoc
@@ -256,12 +311,11 @@
   last: Rismiller
   degree: PhD
   alum: true
-  role: TBD
   year: 2023
   
 - first: Noriana
   last: Radwan
-  role: User Experience Researcher @ Verizon
+  role: UX Researcher @ JPMorganChase
   degree: PhD
   alum: true
   year: 2023
@@ -314,13 +368,6 @@
   year: 2025
   alum: true
   role: Research Scientist @ NYU
-
-- first: Akash
-  last: Agrawal
-  degree: PhD
-  year: 2024
-  alum: true
-  role: Research Engineer II @ ANSYS
 
 - first: Yimika
   last: Osunsanya

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -7,3 +7,5 @@ main:
     url: /publications/
   - title: "Tools & Data"
     url: /tools-and-data/
+  - title: "Join"
+    url: /join/

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -5,3 +5,4 @@
 <link rel="icon" type="image/png" href="{{ '/assets/icons/favicon-16x16.png' | relative_url }}" sizes="16x16">
 <link rel="apple-touch-icon" href="{{ '/assets/icons/apple-touch-icon.png' | relative_url }}">
 <meta name="theme-color" content="#1e3f3e">
+<script defer src="{{ '/assets/javascript/navigation-accessibility.js' | relative_url }}"></script>

--- a/_includes/lab_alum_gallery.html
+++ b/_includes/lab_alum_gallery.html
@@ -1,9 +1,25 @@
-<h3>Alums</h3>
-<ol>
-{% for member in site.data.members %}
-{% if member.alum %}
-  {% assign z = "https://www.linkedin.com/search/results/all/?keywords="| append: {{member.first}} | append: " " | append: {{member.last}} | replace: " ", "%20" %}
-  <li><a href="{{z}}">{{member.first}} {{member.last}}</a>{% if member.degree %}, {{member.degree}}{% endif %}{% if member.year %} {{member.year}}{% endif %}{% if member.role %}, now {{ member.role }}{% endif %}</li>
-{% endif %}
-{% endfor %}
-</ol>
+{% assign alumni = site.data.members | where: "alum", true | sort: "year" | reverse %}
+
+<section class="alumni-section" aria-labelledby="alumni-heading">
+  <h2 id="alumni-heading">Alumni</h2>
+  <p>Our alumni carry design research into academia, industry, government, and public-interest organizations.</p>
+  <details class="alumni-directory">
+    <summary>Browse the alumni directory ({{ alumni.size }})</summary>
+    <div class="alumni-directory__body">
+      <label for="alumni-search">Search alumni by name, degree, year, or current role</label>
+      <input id="alumni-search" class="alumni-search" type="search" inputmode="search" autocomplete="off" placeholder="For example: PhD, 2024, Ansys">
+      <p id="alumni-search-status" class="alumni-search-status" aria-live="polite">Showing all {{ alumni.size }} alumni.</p>
+      <ol id="alumni-list" class="alumni-list">
+      {% for member in alumni %}
+        {% capture member_name %}{{ member.first }} {{ member.last }}{% endcapture %}
+        {% capture search_text %}{{ member_name }} {{ member.degree }} {{ member.year }} {{ member.role }}{% endcapture %}
+        {% assign linkedin_query = member_name | strip | url_encode %}
+        <li data-alumni-entry data-search="{{ search_text | strip | downcase | escape }}">
+          <a href="https://www.linkedin.com/search/results/all/?keywords={{ linkedin_query }}">{{ member_name | strip }}</a>{% if member.degree %}, {{ member.degree }}{% endif %}{% if member.year %} {{ member.year }}{% endif %}{% if member.role %}, now {{ member.role }}{% endif %}
+        </li>
+      {% endfor %}
+      </ol>
+      <p id="alumni-no-results" class="alumni-no-results" hidden>No alumni match that search.</p>
+    </div>
+  </details>
+</section>

--- a/_includes/lab_member_gallery.html
+++ b/_includes/lab_member_gallery.html
@@ -1,33 +1,27 @@
-{% assign counter = 0 %}
+{% assign current_members = site.data.members | where: "alum", false %}
 
-{% for member in site.data.members %}
-{% if member.alum == false %}
-{% assign counter = counter | plus: 1 %}
-{% assign mod = counter | modulo: 3 %}
-{% if mod == 1 %}
-<div class="feature__wrapper">
-{% endif %}
-  <div class="feature__item">
-    <div class="archive__item" style="padding-left: 12.5%; padding-right: 12.5%;">
-      <div class="archive__item-teaser" >
-        {% if member.headshot %}
-          <img src="{{ member.headshot | relative_url }}" alt="{{ member.first }} {{ member.last }}">
-        {% else %}
-          <img src="https://www.cmu.edu/brand/brand-guidelines/images/scottycolors-whiteonred-600x600.png" alt="{{ member.first }} {{ member.last }}">
-        {% endif %}  
-      </div>
-
-      <div class="archive__item-body">
-      <h3 class="archive__item-title" style="text-align: center">{{member.first}} {{member.last}}</h3>
-      <p style="text-align: center">{{ member.role }}{% if member.email %}<br/> <a href="mailto:{{ member.email }}">{{ member.email }}</a> {% endif %}</p>
-      </div> 
+<div class="member-grid">
+{% for member in current_members %}
+  <article class="member-card">
+    {% if member.headshot %}
+    <img class="member-card__photo" src="{{ member.headshot | relative_url }}" alt="" loading="lazy">
+    {% else %}
+    <div class="member-card__placeholder" aria-hidden="true">DRC</div>
+    {% endif %}
+    <div class="member-card__body">
+      <h2 class="member-card__name">
+        {% if member.linkedin %}<a href="{{ member.linkedin }}">{% endif %}{{ member.first }} {{ member.last }}{% if member.linkedin %}</a>{% endif %}
+      </h2>
+      <p class="member-card__role">{{ member.role }}</p>
+      {% if member.keywords %}
+      <ul class="tag-list" aria-label="Research interests">
+        {% for keyword in member.keywords %}
+        <li>{{ keyword }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% if member.email %}<p class="member-card__contact"><a href="mailto:{{ member.email }}">{{ member.email }}</a></p>{% endif %}
     </div>
-  </div>
-{% if mod == 0 %}
-</div>
-{% endif %}
-{% endif %}
+  </article>
 {% endfor %}
-{% if mod != 0 %}
 </div>
-{% endif %}

--- a/_includes/publication_browser.html
+++ b/_includes/publication_browser.html
@@ -1,0 +1,85 @@
+{% assign publication_list = site.data.citations | sort: "Year" | reverse %}
+
+<ol class="publication-list" id="publication-list" data-publication-list>
+{% for citation in publication_list %}
+  {% assign publication_lower = citation.Publication | default: "" | strip | downcase %}
+  {% assign publication_type = "other" %}
+  {% assign is_journal = false %}
+
+  {% if publication_lower contains "http://" or publication_lower contains "https://" %}
+    {% assign publication_type = "trade" %}
+  {% elsif publication_lower contains "arxiv" or publication_lower contains "ssrn" or publication_lower contains "preprint" %}
+    {% assign publication_type = "preprint" %}
+  {% else %}
+    {% for journal in site.publications.journals %}
+      {% assign journal_lower = journal | downcase %}
+      {% if publication_lower == journal_lower %}
+        {% assign is_journal = true %}
+        {% break %}
+      {% endif %}
+    {% endfor %}
+
+    {% if is_journal %}
+      {% assign publication_type = "journal" %}
+    {% elsif publication_lower contains "conference" or publication_lower contains "proceedings" or publication_lower contains "congress" or publication_lower contains "symposium" or publication_lower contains "workshop" or publication_lower contains "annual meeting" or publication_lower contains "neural information processing systems" %}
+      {% assign publication_type = "conference" %}
+    {% endif %}
+  {% endif %}
+
+  {% capture citation_authors %}{% for element in citation %}{% if forloop.first %}{{ element[1] }}{% endif %}{% endfor %}{% endcapture %}
+  {% assign citation_authors = citation_authors | strip %}
+  {% assign author_size = citation_authors | size | minus: 1 %}
+  {% assign publication_authors = citation_authors | slice: 0, author_size | split: ";" %}
+
+  {% assign last_names = "" %}
+  {% assign first_names = "" %}
+  {% for name in publication_authors %}
+    {% assign first_last = name | split: "," %}
+    {% assign first_names = first_names | append: first_last[1] %}
+    {% assign last_names = last_names | append: first_last[0] %}
+    {% unless forloop.last %}
+      {% assign last_names = last_names | append: ";" %}
+      {% assign first_names = first_names | append: ";" %}
+    {% endunless %}
+  {% endfor %}
+  {% assign first_names = first_names | split: ";" %}
+  {% assign last_names = last_names | split: ";" %}
+
+  {% assign formatted_author_list = "" %}
+  {% for first_name in first_names %}
+    {% assign first_initial = first_name | slice: 1 %}
+    {% assign formatted_author_list = formatted_author_list | append: last_names[forloop.index0] | append: ", " | append: first_initial | append: "." %}
+    {% unless forloop.last %}
+      {% assign formatted_author_list = formatted_author_list | append: ";" %}
+    {% endunless %}
+  {% endfor %}
+
+  {% if publication_type == "trade" %}
+    {% assign publication_url = citation.Publication %}
+  {% elsif citation.DOI and citation.DOI != "" %}
+    {% assign publication_url = citation.DOI %}
+  {% else %}
+    {% assign publication_url = citation.Title | cgi_escape | prepend: "https://scholar.google.com/scholar?q=" %}
+  {% endif %}
+
+  {% assign publication_label = citation.Publication %}
+  {% if publication_type == "trade" %}
+    {% if publication_lower contains "thearcticinstitute.org" %}
+      {% assign publication_label = "The Arctic Institute" %}
+    {% else %}
+      {% assign publication_label = "Trade publication" %}
+    {% endif %}
+  {% endif %}
+
+  {% capture publication_search_text %}{{ citation_authors }} {{ citation.Title }} {{ citation.Publication }} {{ citation.Year }} {{ citation.Publisher }}{% endcapture %}
+  <li
+    data-publication-entry
+    data-publication-type="{{ publication_type }}"
+    data-publication-year="{{ citation.Year | escape }}"
+    data-publication-title="{{ citation.Title | escape }}"
+    data-publication-search="{{ publication_search_text | strip_newlines | escape }}"
+    data-publication-index="{{ forloop.index0 }}">
+    {{ formatted_author_list | split: ";" | array_to_sentence_string: "&" }} ({{ citation.Year }}). <a href="{{ publication_url | escape }}">{{ citation.Title }}</a>.{% if publication_label and publication_label != "" %} <em>{{ publication_label }}</em>.{% endif %}
+  </li>
+{% endfor %}
+</ol>

--- a/_pages/join.md
+++ b/_pages/join.md
@@ -1,0 +1,31 @@
+---
+layout: splash
+classes: wide solid-hero
+title: Join
+permalink: /join/
+header:
+  og_image: "/assets/social-card.png"
+  og_image_alt: "Carnegie Mellon University Design Research Collective"
+  overlay_color: "#1e3f3e"
+  excerpt: "For prospective students, research collaborators, and organizations interested in designing better human–AI systems."
+---
+
+The Design Research Collective is multidisciplinary by design. Our members come from mechanical and aerospace engineering, computer science and data science, architecture and design, public policy, and the social sciences. What connects us is a shared interest in how people, AI systems, and engineered systems shape one another.
+
+<div class="join-grid">
+  <section class="join-card">
+    <h3>Doctoral research</h3>
+    <p>The lab runs a separate admissions process for prospective Ph.D. researchers. We also encourage interested applicants to apply directly to the Carnegie Mellon graduate program that best fits their preparation and research goals.</p>
+    <p><a href="mailto:ccm@cmu.edu?subject=Prospective Ph.D. researcher interested in the DRC">Ask about lab admissions</a><br><a href="https://meche.engineering.cmu.edu/education/graduate-programs/admission/index.html">Apply through Mechanical Engineering</a></p>
+  </section>
+  <section class="join-card">
+    <h3>Current CMU students</h3>
+    <p>Master’s and undergraduate students often contribute through a research project, independent study, or thesis. Opportunities depend on project needs, preparation, and advising capacity.</p>
+    <p><a href="mailto:ccm@cmu.edu?subject=Current CMU student interested in DRC research">Introduce your interests</a></p>
+  </section>
+  <section class="join-card">
+    <h3>Research and industry collaboration</h3>
+    <p>We work with academic, government, and industry partners on questions that connect human–AI collaboration with consequential engineering practice.</p>
+    <p><a href="mailto:ccm@cmu.edu?subject=Potential DRC collaboration">Start a conversation</a></p>
+  </section>
+</div>

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -1,24 +1,53 @@
 ---
 layout: splash
-classes: wide
+classes: wide solid-hero
 title: Publications
 permalink: /publications/
 header:
   og_image: "/assets/social-card.png"
   og_image_alt: "Carnegie Mellon University Design Research Collective"
-  overlay_filter: linear-gradient(rgba(0, 0, 0, 0.5), rgba(223, 81, 39, 0.5))
-  overlay_image: "https://images.unsplash.com/photo-1595694548657-8e6f0d681f8a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1776&q=80"
-  caption: "[**Evy Prentice**](https://unsplash.com/@evy_prentice) on [*Unsplash*](https://unsplash.com)"
+  overlay_color: "#1e3f3e"
+  excerpt: "Search the lab's journal articles, conference papers, preprints, and public-facing research writing."
 ---
-## Journal
-{% assign journal_list = site.publications.journals | join: ";" %}
-{% include publications venue=journal_list link=true %}
+<p>This index is generated from the lab's publication data. New records become searchable and sortable without additional page maintenance.</p>
 
-## Conference
-{% include publications venue_search="congress;symposium;conference" link=true %}
+<div class="publication-browser" data-publication-browser>
+  <div class="catalog-toolbar publication-toolbar" role="search" aria-label="Search and filter publications" data-publication-controls>
+    <div class="catalog-control catalog-control--search">
+      <label for="publication-search">Search publications</label>
+      <input id="publication-search" type="search" autocomplete="off" placeholder="Author, title, venue, topic, or year" aria-controls="publication-list" data-publication-query>
+    </div>
+    <div class="catalog-control">
+      <label for="publication-type">Type</label>
+      <select id="publication-type" aria-controls="publication-list" data-publication-type>
+        <option value="all">All types</option>
+        <option value="journal">Journal</option>
+        <option value="conference">Conference</option>
+        <option value="preprint">Preprint</option>
+        <option value="trade">Trade publication</option>
+        <option value="other">Other</option>
+      </select>
+    </div>
+    <div class="catalog-control">
+      <label for="publication-year">Year</label>
+      <select id="publication-year" aria-controls="publication-list" data-publication-year>
+        <option value="all">All years</option>
+      </select>
+    </div>
+    <div class="catalog-control">
+      <label for="publication-sort">Sort</label>
+      <select id="publication-sort" aria-controls="publication-list" data-publication-sort>
+        <option value="newest">Newest first</option>
+        <option value="oldest">Oldest first</option>
+        <option value="title">Title, A–Z</option>
+      </select>
+    </div>
+    <button class="btn btn--primary catalog-toolbar__action" type="button" data-publication-reset>Reset</button>
+  </div>
 
-## Preprints
-{% include publications venue_search="arxiv;ssrn" link=true %}
+  <p class="catalog-status" data-publication-status aria-live="polite" aria-atomic="true">Showing all {{ site.data.citations | size }} publications.</p>
+  {% include publication_browser.html %}
+  <p class="catalog-empty" data-publication-empty hidden>No publications match these filters.</p>
+</div>
 
-## Trade Publications
-{% include trade_publications.html %}
+<script defer src="{{ '/assets/javascript/publication-browser.js' | relative_url }}"></script>

--- a/_pages/software.md
+++ b/_pages/software.md
@@ -1,28 +1,57 @@
 ---
 layout: splash
-classes: wide
+classes: wide solid-hero
 title: Tools & Data
 permalink: /tools-and-data/
 header:
   og_image: "/assets/social-card.png"
   og_image_alt: "Carnegie Mellon University Design Research Collective"
-  overlay_filter: linear-gradient(rgba(0, 0, 0, 0.5), rgba(87, 183, 186, 0.5))
-  overlay_image: "https://images.unsplash.com/photo-1594729095022-e2f6d2eece9c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1771&q=80"
-  caption: "[**Markus Spiske**](https://unsplash.com/@markusspiske) on [*Unsplash*](https://unsplash.com)"
-gallery:
-  - url: "https://github.com/THREDgroup/kaboom"
-    image_path: /assets/software/kaboom.png
-    title: "KABOOM"
-  - url: "https://github.com/hyform"
-    image_path: "https://raw.githubusercontent.com/hyform/branding/master/LOGO/PNG/Hyform-07.png"
-    title: "HyForm"
-  - url: "https://github.com/mccomblab/mccomblab.github.io"
-    image_path: /assets/software/mccomblab.png
-    title: "mccomblab.github.io"
-  - url: "https://github.com/mccomblab/show-me-the-funding"
-    image_path: "https://raw.githubusercontent.com/mccomblab/show-me-the-funding/master/assets/screenshot.png"
-    title: "Show Me The Funding"
+  overlay_color: "#1e3f3e"
+  excerpt: "Open tools, benchmarks, datasets, and research infrastructure for human-centered AI and computational engineering design."
 ---
 
+We release research artifacts when they can make results easier to inspect, reproduce, or build upon. Search the live inventory below to find public software, datasets, models, and interactive demos.
 
-{% include gallery %}
+<section class="resource-section live-catalog" aria-labelledby="live-catalog-heading" data-live-tool-catalog>
+  <h2 id="live-catalog-heading">Live public catalog</h2>
+  <p>This index updates automatically from the lab's public <a href="https://github.com/cmudrc">GitHub organization</a> and <a href="https://huggingface.co/cmudrc">Hugging Face collections</a>, including datasets, models, and interactive Spaces. It omits templates, site administration, and manuscript-only bundles.</p>
+
+  <div class="catalog-toolbar" role="search" aria-label="Filter the public tools and data catalog">
+    <div class="catalog-control catalog-control--search">
+      <label for="tool-catalog-search">Search tools and data</label>
+      <input id="tool-catalog-search" type="search" autocomplete="off" placeholder="Name, description, language, or topic" aria-controls="tool-catalog">
+    </div>
+    <div class="catalog-control">
+      <label for="tool-catalog-source">Source</label>
+      <select id="tool-catalog-source" aria-controls="tool-catalog">
+        <option value="all">All sources</option>
+        <option value="github">GitHub</option>
+        <option value="hugging-face">Hugging Face</option>
+      </select>
+    </div>
+    <div class="catalog-control">
+      <label for="tool-catalog-type">Resource type</label>
+      <select id="tool-catalog-type" aria-controls="tool-catalog">
+        <option value="all">All resource types</option>
+        <option value="software">Software repositories</option>
+        <option value="dataset">Datasets</option>
+        <option value="model">Models</option>
+        <option value="space">Interactive demos</option>
+      </select>
+    </div>
+    <div class="catalog-control">
+      <label for="tool-catalog-sort">Sort</label>
+      <select id="tool-catalog-sort" aria-controls="tool-catalog">
+        <option value="recent">Recently updated</option>
+        <option value="title">Name, A–Z</option>
+      </select>
+    </div>
+  </div>
+
+  <p class="catalog-status" id="tool-catalog-status" role="status" aria-live="polite" aria-atomic="true">Loading the live catalog…</p>
+  <div class="resource-grid" id="tool-catalog" aria-busy="true"></div>
+  <button class="btn btn--primary catalog-show-all" id="tool-catalog-show-all" type="button" hidden>Show all items</button>
+  <noscript><p>The live inventory requires JavaScript. Browse the complete catalog on <a href="https://github.com/cmudrc">GitHub</a> and <a href="https://huggingface.co/cmudrc">Hugging Face</a>.</p></noscript>
+</section>
+
+<script defer src="{{ '/assets/javascript/live-tool-catalog.js' | relative_url }}"></script>

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -2,13 +2,14 @@
 title: Team
 permalink: /team/
 layout: splash
+classes: wide solid-hero
 header:
   og_image: "/assets/social-card.png"
   og_image_alt: "Carnegie Mellon University Design Research Collective"
-  overlay_filter: linear-gradient(rgba(0, 0, 0, 0.5), rgba(77, 134, 135, 0.5))
-  overlay_image: "https://images.unsplash.com/photo-1494059980473-813e73ee784b?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1769&q=80"
-  caption: "[**Hans-Peter Gauster**](https://unsplash.com/@sloppyperfectionist) on [*Unsplash*](https://unsplash.com)"
+  overlay_color: "#1e3f3e"
 ---
 
-{% include lab_member_gallery.html%}
-{% include lab_alum_gallery.html%}
+{% include lab_member_gallery.html %}
+{% include lab_alum_gallery.html %}
+
+<script defer src="{{ '/assets/javascript/alumni-search.js' | relative_url }}"></script>

--- a/_sass/minimal-mistakes/skins/_drc.scss
+++ b/_sass/minimal-mistakes/skins/_drc.scss
@@ -120,9 +120,9 @@ $caption-font-family: $serif !default;
 // $youtube-color: #bb0000 !default;
 // $xing-color: #006567 !default;
 
-/* links */
-$link-color: $cmu-drc-blue !default;
-$link-color-hover: $cmu-drc-teal !default;
+/* links: darker brand tones preserve contrast on white backgrounds */
+$link-color: #2f6f71 !default;
+$link-color-hover: $cmu-drc-forest !default;
 $link-color-visited: $cmu-drc-forest !default;
 // $masthead-link-color: $primary-color !default;
 // $masthead-link-color-hover: mix(#000, $primary-color, 25%) !default;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -41,3 +41,452 @@ search: false
 .site-title {
   display: none !important;
 }
+
+// Shared interaction and content patterns
+:focus-visible {
+  outline: 3px solid #df5127;
+  outline-offset: 3px;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.greedy-nav a[aria-current="page"] {
+  color: #1e3f3e;
+  text-decoration: underline;
+  text-decoration-thickness: 0.15em;
+  text-underline-offset: 0.25em;
+}
+
+.solid-hero .page__hero--overlay {
+  background-image: none !important;
+}
+
+.page__hero-caption {
+  padding: 0.2rem 0.4rem;
+  background: #1e3f3e;
+  color: #fff;
+  opacity: 1 !important;
+}
+
+.page__hero-caption a,
+.page__hero-caption a:visited {
+  color: #fff;
+}
+
+.archive__item-caption {
+  padding: 0.2rem 0.4rem;
+  background: #1e3f3e;
+  color: #fff;
+  opacity: 1 !important;
+}
+
+.archive__item-caption a,
+.archive__item-caption a:visited {
+  color: #fff;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.85rem 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tag-list li {
+  margin: 0;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(77, 134, 135, 0.13);
+  color: #1e3f3e;
+  font-size: 0.75em;
+  line-height: 1.25;
+  text-transform: none;
+}
+
+// Tools and data catalog
+.resource-section {
+  margin-top: 2.5rem;
+}
+
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.resource-card,
+.join-card {
+  display: flex;
+  flex-direction: column;
+  padding: 1.35rem;
+  border: 1px solid #d9e1e1;
+  border-top: 0.35rem solid #4d8687;
+  border-radius: 0.35rem;
+  background: #fff;
+  box-shadow: 0 0.25rem 0.8rem rgba(30, 63, 62, 0.08);
+}
+
+.resource-card h3,
+.join-card h3 {
+  margin-top: 0.15rem;
+}
+
+.resource-card__type {
+  margin: 0;
+  color: #4d6868;
+  font-family: $sans-serif;
+  font-size: 0.72em;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.resource-card__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin: auto 0 0;
+  padding: 1rem 0 0;
+  list-style: none;
+}
+
+.resource-card__links li {
+  margin: 0;
+}
+
+.resource-card__links a {
+  font-family: $sans-serif;
+}
+
+.resource-card__meta {
+  margin: 0.25rem 0 0;
+  color: #4d5d5d;
+  font-size: 0.78em;
+}
+
+.live-resource-card h3 {
+  overflow-wrap: anywhere;
+}
+
+.live-resource-card {
+  --card-accent: #4d8687;
+  --card-surface: #f7fafa;
+  --card-wash: rgba(77, 134, 135, 0.12);
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border-top-color: var(--card-accent);
+  background-color: var(--card-surface);
+  transition: box-shadow 180ms ease, transform 180ms ease;
+}
+
+.live-resource-card--dataset {
+  --card-accent: #2f6f71;
+  --card-surface: #f2f8f8;
+  --card-wash: rgba(87, 183, 186, 0.14);
+}
+
+.live-resource-card--model {
+  --card-accent: #b44425;
+  --card-surface: #fcf6f3;
+  --card-wash: rgba(223, 81, 39, 0.12);
+}
+
+.live-resource-card--space {
+  --card-accent: #9a5d1f;
+  --card-surface: #fcf8f1;
+  --card-wash: rgba(234, 133, 52, 0.14);
+}
+
+.live-resource-card::after {
+  position: absolute;
+  z-index: -1;
+  top: -2.8rem;
+  right: -2.8rem;
+  width: 6.5rem;
+  height: 6.5rem;
+  border: 0.65rem solid var(--card-accent);
+  border-radius: 50%;
+  content: "";
+  opacity: 0.09;
+  pointer-events: none;
+}
+
+.live-resource-card .resource-card__type {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem 0.55rem;
+}
+
+.resource-card__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.28rem 0.5rem;
+  border-radius: 999px;
+  line-height: 1.1;
+}
+
+.resource-card__badge--source {
+  background: rgba(30, 63, 62, 0.07);
+}
+
+.resource-card__badge--kind {
+  background: var(--card-wash);
+}
+
+.resource-card__badge i {
+  color: var(--card-accent);
+  font-size: 0.95em;
+}
+
+.resource-card__emoji {
+  font-size: 1.05em;
+  line-height: 1;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .live-resource-card:hover,
+  .live-resource-card:focus-within {
+    box-shadow: 0 0.55rem 1.25rem rgba(30, 63, 62, 0.16);
+    transform: translateY(-0.18rem);
+  }
+}
+
+// Search and filter controls
+.catalog-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1rem;
+  margin: 1.5rem 0 1rem;
+  padding: 1rem;
+  border: 1px solid #c8d4d4;
+  border-radius: 0.35rem;
+  background: #f3f7f7;
+}
+
+.catalog-control {
+  flex: 1 1 9rem;
+}
+
+.catalog-control--search {
+  flex: 2 1 20rem;
+}
+
+.catalog-control label {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: #1e3f3e;
+  font-family: $sans-serif;
+  font-size: 0.85em;
+}
+
+.catalog-control input,
+.catalog-control select {
+  width: 100%;
+  min-height: 2.75rem;
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid #718787;
+  border-radius: 0.25rem;
+  background: #fff;
+  color: #222;
+  font: inherit;
+}
+
+.catalog-toolbar__action {
+  min-height: 2.75rem;
+  margin: 0;
+}
+
+.catalog-status {
+  color: #4d5d5d;
+  font-size: 0.88em;
+}
+
+.catalog-show-all {
+  margin-top: 1.25rem;
+}
+
+.catalog-empty {
+  grid-column: 1 / -1;
+  padding: 0.9rem 1rem;
+  border-left: 0.3rem solid #df5127;
+  background: #f8fafa;
+}
+
+// Publications browser
+.publication-browser {
+  margin-top: 1.5rem;
+}
+
+.publication-toolbar .catalog-control {
+  flex-basis: 8rem;
+}
+
+.publication-toolbar .catalog-control--search {
+  flex-basis: 18rem;
+}
+
+.publication-list li {
+  margin-bottom: 0.85rem;
+  padding-left: 0.25rem;
+}
+
+// Team and alumni directory
+.member-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.member-card {
+  overflow: hidden;
+  border: 1px solid #d9e1e1;
+  border-radius: 0.35rem;
+  background: #fff;
+  box-shadow: 0 0.25rem 0.8rem rgba(30, 63, 62, 0.08);
+}
+
+.member-card__photo,
+.member-card__placeholder {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+}
+
+.member-card__photo {
+  display: block;
+  object-fit: cover;
+}
+
+.member-card__placeholder {
+  display: grid;
+  place-items: center;
+  background: #1e3f3e;
+  color: #fff;
+  font-family: $sans-serif;
+  font-size: 2rem;
+}
+
+.member-card__body {
+  padding: 1.1rem;
+}
+
+.member-card__name {
+  margin: 0;
+  font-size: 1.05em;
+  text-align: left;
+}
+
+.member-card__role,
+.member-card__contact {
+  margin: 0.4rem 0 0;
+}
+
+.member-card__contact {
+  overflow-wrap: anywhere;
+  font-size: 0.85em;
+}
+
+.alumni-section {
+  margin-top: 3rem;
+}
+
+.alumni-directory {
+  border: 1px solid #c8d4d4;
+  border-radius: 0.35rem;
+  background: #f8fafa;
+}
+
+.alumni-directory summary {
+  padding: 1rem 1.2rem;
+  color: #1e3f3e;
+  cursor: pointer;
+  font-family: $sans-serif;
+}
+
+.alumni-directory__body {
+  padding: 0 1.2rem 1.2rem;
+}
+
+.alumni-directory label {
+  display: block;
+  margin: 0.5rem 0;
+  font-family: $sans-serif;
+}
+
+.alumni-search {
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid #718787;
+  border-radius: 0.25rem;
+  background: #fff;
+  color: #222;
+  font: inherit;
+}
+
+.alumni-search-status {
+  color: #4d5d5d;
+  font-size: 0.85em;
+}
+
+.alumni-list li {
+  margin-bottom: 0.45rem;
+}
+
+.alumni-no-results {
+  padding: 0.75rem;
+  border-left: 0.3rem solid #df5127;
+  background: #fff;
+}
+
+// Join page
+.join-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.join-card p:last-child {
+  margin-top: auto;
+}
+
+@media (max-width: 900px) {
+  .resource-grid,
+  .member-grid,
+  .join-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .resource-grid,
+  .member-grid,
+  .join-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .catalog-control,
+  .catalog-control--search,
+  .catalog-toolbar__action {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/assets/javascript/alumni-search.js
+++ b/assets/javascript/alumni-search.js
@@ -1,0 +1,42 @@
+(function () {
+  "use strict";
+
+  function normalize(value) {
+    return value.toLowerCase().replace(/\s+/g, " ").trim();
+  }
+
+  function initializeAlumniSearch() {
+    var input = document.getElementById("alumni-search");
+    var entries = Array.prototype.slice.call(document.querySelectorAll("[data-alumni-entry]"));
+    var status = document.getElementById("alumni-search-status");
+    var noResults = document.getElementById("alumni-no-results");
+
+    if (!input || !entries.length || !status || !noResults) {
+      return;
+    }
+
+    input.addEventListener("input", function () {
+      var query = normalize(input.value);
+      var visibleCount = 0;
+
+      entries.forEach(function (entry) {
+        var matches = !query || normalize(entry.dataset.search || "").indexOf(query) !== -1;
+        entry.hidden = !matches;
+        if (matches) {
+          visibleCount += 1;
+        }
+      });
+
+      noResults.hidden = visibleCount !== 0;
+      status.textContent = query
+        ? "Showing " + visibleCount + " of " + entries.length + " alumni."
+        : "Showing all " + entries.length + " alumni.";
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeAlumniSearch);
+  } else {
+    initializeAlumniSearch();
+  }
+})();

--- a/assets/javascript/live-tool-catalog.js
+++ b/assets/javascript/live-tool-catalog.js
@@ -1,0 +1,439 @@
+(function () {
+  "use strict";
+
+  const section = document.querySelector("[data-live-tool-catalog]");
+
+  if (!section) {
+    return;
+  }
+
+  const catalog = section.querySelector("#tool-catalog");
+  const queryInput = section.querySelector("#tool-catalog-search");
+  const sourceSelect = section.querySelector("#tool-catalog-source");
+  const typeSelect = section.querySelector("#tool-catalog-type");
+  const sortSelect = section.querySelector("#tool-catalog-sort");
+  const status = section.querySelector("#tool-catalog-status");
+  const showAllButton = section.querySelector("#tool-catalog-show-all");
+  const dateFormatter = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric"
+  });
+  const collator = new Intl.Collator("en", { sensitivity: "base" });
+  const initialLimit = 18;
+  const administrativeRepositories = new Set([
+    "branding",
+    "cmudrc.github.io",
+    "prepare-asme-submission-package"
+  ]);
+  const manuscriptOnlyPattern = /(paper|supplement|submission)/i;
+  let items = [];
+  const loadedSources = new Set();
+  let showAll = false;
+
+  if (!catalog || !queryInput || !sourceSelect || !typeSelect || !sortSelect || !status || !showAllButton) {
+    return;
+  }
+
+  function normalize(value) {
+    return String(value || "")
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase();
+  }
+
+  function cleanDescription(value) {
+    return String(value || "")
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+      .replace(/<[^>]*>/g, " ")
+      .replace(/[#*_`>|]+/g, " ")
+      .replace(/https?:\/\/\S+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  function summarize(value, fallback) {
+    const description = cleanDescription(value) || fallback;
+
+    if (description.length <= 220) {
+      return description;
+    }
+
+    const shortened = description.slice(0, 217);
+    const lastSpace = shortened.lastIndexOf(" ");
+    return shortened.slice(0, lastSpace > 150 ? lastSpace : 217).trimEnd() + "…";
+  }
+
+  function sentenceCase(value) {
+    const label = String(value || "").replace(/[-_]+/g, " ").trim();
+    return label ? label.charAt(0).toUpperCase() + label.slice(1) : "";
+  }
+
+  function sourceListLabel() {
+    if (loadedSources.size === 2) {
+      return "GitHub and Hugging Face";
+    }
+
+    return Array.from(loadedSources)[0] || "the public source APIs";
+  }
+
+  function formatDate(value) {
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return {
+      iso: date.toISOString(),
+      label: dateFormatter.format(date),
+      timestamp: date.getTime()
+    };
+  }
+
+  async function fetchJson(url) {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error("Request failed with status " + response.status);
+    }
+
+    const data = await response.json();
+
+    if (!Array.isArray(data)) {
+      throw new Error("The source returned an unexpected response.");
+    }
+
+    return data;
+  }
+
+  function githubItems(repositories) {
+    return repositories.filter(function (repository) {
+      return repository &&
+        !repository.archived &&
+        !repository.disabled &&
+        !repository.fork &&
+        !repository.is_template &&
+        !administrativeRepositories.has(repository.name) &&
+        !manuscriptOnlyPattern.test(repository.name);
+    }).map(function (repository) {
+      const date = formatDate(repository.pushed_at || repository.updated_at);
+      const language = repository.language || "Software";
+      const topics = Array.isArray(repository.topics) ? repository.topics : [];
+
+      return {
+        name: repository.name,
+        source: "github",
+        category: "software",
+        sourceLabel: "GitHub",
+        kind: language + " repository",
+        description: summarize(
+          repository.description,
+          "Public research software from the Design Research Collective."
+        ),
+        url: repository.html_url,
+        updated: date,
+        search: normalize([
+          repository.name,
+          repository.description,
+          language,
+          topics.join(" "),
+          "GitHub repository software code"
+        ].join(" "))
+      };
+    });
+  }
+
+  function huggingFaceItems(datasets) {
+    return datasets.filter(function (dataset) {
+      return dataset &&
+        typeof dataset.id === "string" &&
+        dataset.id.startsWith("cmudrc/") &&
+        !dataset.private &&
+        !dataset.disabled &&
+        !dataset.gated;
+    }).map(function (dataset) {
+      const name = dataset.id.split("/").slice(1).join("/");
+      const tags = Array.isArray(dataset.tags) ? dataset.tags : [];
+
+      return {
+        name: name,
+        source: "hugging-face",
+        category: "dataset",
+        sourceLabel: "Hugging Face",
+        kind: "Dataset",
+        description: summarize(
+          dataset.description,
+          "Public research dataset from the Design Research Collective."
+        ),
+        url: "https://huggingface.co/datasets/" + dataset.id,
+        updated: formatDate(dataset.lastModified),
+        search: normalize([
+          name,
+          dataset.description,
+          tags.join(" "),
+          "Hugging Face dataset data"
+        ].join(" "))
+      };
+    });
+  }
+
+  function huggingFaceModelItems(models) {
+    return models.filter(function (model) {
+      return model &&
+        typeof model.id === "string" &&
+        model.id.startsWith("cmudrc/") &&
+        !model.private &&
+        !model.disabled &&
+        (model.gated === false || model.gated == null);
+    }).map(function (model) {
+      const name = model.id.split("/").slice(1).join("/");
+      const tags = Array.isArray(model.tags) ? model.tags : [];
+      const task = String(model.pipeline_tag || "research").replace(/[-_]+/g, " ");
+
+      return {
+        name: name,
+        source: "hugging-face",
+        category: "model",
+        sourceLabel: "Hugging Face",
+        kind: sentenceCase(task) + " model",
+        description: summarize(
+          model.description,
+          "Public " + task + " model from the Design Research Collective."
+        ),
+        url: "https://huggingface.co/" + model.id,
+        updated: formatDate(model.lastModified),
+        search: normalize([
+          name,
+          model.description,
+          task,
+          tags.join(" "),
+          "Hugging Face model"
+        ].join(" "))
+      };
+    });
+  }
+
+  function huggingFaceSpaceItems(spaces) {
+    return spaces.filter(function (space) {
+      return space &&
+        typeof space.id === "string" &&
+        space.id.startsWith("cmudrc/") &&
+        !space.private &&
+        !space.disabled &&
+        (space.gated === false || space.gated == null);
+    }).map(function (space) {
+      const name = space.id.split("/").slice(1).join("/");
+      const tags = Array.isArray(space.tags) ? space.tags : [];
+      const sdk = String(space.sdk || "hosted").replace(/[-_]+/g, " ");
+
+      return {
+        name: name,
+        source: "hugging-face",
+        category: "space",
+        sourceLabel: "Hugging Face",
+        kind: sentenceCase(sdk) + " interactive demo",
+        description: summarize(
+          space.description,
+          "Interactive research application built with " + sdk + "."
+        ),
+        url: "https://huggingface.co/spaces/" + space.id,
+        updated: formatDate(space.lastModified),
+        search: normalize([
+          name,
+          space.description,
+          sdk,
+          tags.join(" "),
+          "Hugging Face Space GUI app demo"
+        ].join(" "))
+      };
+    });
+  }
+
+  function compareItems(a, b) {
+    if (sortSelect.value === "title") {
+      return collator.compare(a.name, b.name) || collator.compare(a.sourceLabel, b.sourceLabel);
+    }
+
+    const aTimestamp = a.updated ? a.updated.timestamp : 0;
+    const bTimestamp = b.updated ? b.updated.timestamp : 0;
+    return bTimestamp - aTimestamp || collator.compare(a.name, b.name);
+  }
+
+  function createCard(item) {
+    const card = document.createElement("article");
+    const type = document.createElement("p");
+    const sourceBadge = document.createElement("span");
+    const sourceText = document.createElement("span");
+    const kindBadge = document.createElement("span");
+    const kindIcon = document.createElement("i");
+    const kindText = document.createElement("span");
+    const heading = document.createElement("h3");
+    const description = document.createElement("p");
+    const metadata = document.createElement("p");
+    const links = document.createElement("ul");
+    const linkItem = document.createElement("li");
+    const link = document.createElement("a");
+
+    card.className = "resource-card live-resource-card live-resource-card--" + item.category;
+    type.className = "resource-card__type";
+    sourceBadge.className = "resource-card__badge resource-card__badge--source";
+    sourceText.textContent = item.sourceLabel;
+
+    if (item.source === "github") {
+      const sourceIcon = document.createElement("i");
+      sourceIcon.className = "fab fa-github";
+      sourceIcon.setAttribute("aria-hidden", "true");
+      sourceBadge.append(sourceIcon);
+    } else {
+      const sourceIcon = document.createElement("span");
+      sourceIcon.className = "resource-card__emoji";
+      sourceIcon.setAttribute("aria-hidden", "true");
+      sourceIcon.textContent = "🤗";
+      sourceBadge.append(sourceIcon);
+    }
+
+    sourceBadge.append(sourceText);
+    kindBadge.className = "resource-card__badge resource-card__badge--kind";
+    kindIcon.className = {
+      dataset: "fas fa-database",
+      model: "fas fa-brain",
+      software: "fas fa-code",
+      space: "fas fa-window-maximize"
+    }[item.category] || "fas fa-cube";
+    kindIcon.setAttribute("aria-hidden", "true");
+    kindText.textContent = item.kind;
+    kindBadge.append(kindIcon, kindText);
+    type.append(sourceBadge, kindBadge);
+    heading.textContent = item.name;
+    description.textContent = item.description;
+    metadata.className = "resource-card__meta";
+
+    if (item.updated) {
+      const time = document.createElement("time");
+      time.dateTime = item.updated.iso;
+      time.textContent = "Updated " + item.updated.label;
+      metadata.append(time);
+    } else {
+      metadata.textContent = "Update date unavailable";
+    }
+
+    links.className = "resource-card__links";
+    links.setAttribute("aria-label", "Links for " + item.name);
+    link.href = item.url;
+    if (item.category === "model") {
+      link.textContent = "View model";
+    } else if (item.category === "space") {
+      link.textContent = "Open interactive demo";
+    } else if (item.category === "dataset") {
+      link.textContent = "View dataset";
+    } else {
+      link.textContent = "View repository";
+    }
+    linkItem.append(link);
+    links.append(linkItem);
+    card.append(type, heading, description, metadata, links);
+    return card;
+  }
+
+  function renderCatalog() {
+    const queryTerms = normalize(queryInput.value).split(/\s+/).filter(Boolean);
+    const selectedSource = sourceSelect.value;
+    const selectedType = typeSelect.value;
+    const matchingItems = items.filter(function (item) {
+      const matchesQuery = queryTerms.every(function (term) {
+        return item.search.includes(term);
+      });
+      const matchesSource = selectedSource === "all" || item.source === selectedSource;
+      const matchesType = selectedType === "all" || item.category === selectedType;
+      return matchesQuery && matchesSource && matchesType;
+    }).sort(compareItems);
+    const visibleItems = showAll ? matchingItems : matchingItems.slice(0, initialLimit);
+    const fragment = document.createDocumentFragment();
+
+    if (matchingItems.length === 0) {
+      const empty = document.createElement("p");
+      empty.className = "catalog-empty";
+      empty.textContent = "No public resources match these filters.";
+      fragment.append(empty);
+    } else {
+      visibleItems.forEach(function (item) {
+        fragment.append(createCard(item));
+      });
+    }
+
+    catalog.replaceChildren(fragment);
+    catalog.setAttribute("aria-busy", "false");
+    showAllButton.hidden = showAll || matchingItems.length <= initialLimit;
+    showAllButton.textContent = "Show all " + matchingItems.length + " items";
+
+    if (matchingItems.length === items.length && visibleItems.length < matchingItems.length) {
+      status.textContent = "Showing the newest " + visibleItems.length + " of " + matchingItems.length + " live items from " + sourceListLabel() + ".";
+    } else {
+      status.textContent = "Showing " + visibleItems.length + " of " + matchingItems.length + " matching items (" + items.length + " total) from " + sourceListLabel() + ".";
+    }
+  }
+
+  queryInput.addEventListener("input", function () {
+    showAll = false;
+    renderCatalog();
+  });
+  sourceSelect.addEventListener("change", function () {
+    showAll = false;
+    renderCatalog();
+  });
+  typeSelect.addEventListener("change", function () {
+    showAll = false;
+    renderCatalog();
+  });
+  sortSelect.addEventListener("change", renderCatalog);
+  showAllButton.addEventListener("click", function () {
+    showAll = true;
+    renderCatalog();
+  });
+
+  const githubRequest = fetchJson("https://api.github.com/orgs/cmudrc/repos?per_page=100&type=public&sort=pushed&direction=desc");
+  const huggingFaceDatasetRequest = fetchJson("https://huggingface.co/api/datasets?author=cmudrc&limit=100&full=true");
+  const huggingFaceModelRequest = fetchJson("https://huggingface.co/api/models?author=cmudrc&limit=100&full=true");
+  const huggingFaceSpaceRequest = fetchJson("https://huggingface.co/api/spaces?author=cmudrc&limit=100&full=true");
+
+  Promise.allSettled([
+    githubRequest,
+    huggingFaceDatasetRequest,
+    huggingFaceModelRequest,
+    huggingFaceSpaceRequest
+  ]).then(function (results) {
+    if (results[0].status === "fulfilled") {
+      items = items.concat(githubItems(results[0].value));
+      loadedSources.add("GitHub");
+    }
+
+    if (results[1].status === "fulfilled") {
+      items = items.concat(huggingFaceItems(results[1].value));
+      loadedSources.add("Hugging Face");
+    }
+
+    if (results[2].status === "fulfilled") {
+      items = items.concat(huggingFaceModelItems(results[2].value));
+      loadedSources.add("Hugging Face");
+    }
+
+    if (results[3].status === "fulfilled") {
+      items = items.concat(huggingFaceSpaceItems(results[3].value));
+      loadedSources.add("Hugging Face");
+    }
+
+    if (items.length === 0) {
+      const error = document.createElement("p");
+      error.className = "catalog-empty";
+      error.textContent = "The live catalog could not be loaded. Try again or browse the lab's public profiles using the links above.";
+      catalog.replaceChildren(error);
+      catalog.setAttribute("aria-busy", "false");
+      status.textContent = "Live catalog unavailable.";
+      return;
+    }
+
+    renderCatalog();
+  });
+}());

--- a/assets/javascript/navigation-accessibility.js
+++ b/assets/javascript/navigation-accessibility.js
@@ -1,0 +1,45 @@
+(function () {
+  "use strict";
+
+  function normalizePath(path) {
+    var normalized = path.replace(/index\.html$/, "").replace(/\/+$/, "");
+    return normalized || "/";
+  }
+
+  function initializeNavigationAccessibility() {
+    var toggle = document.querySelector(".greedy-nav__toggle");
+    var overflowMenu = document.querySelector(".greedy-nav .hidden-links");
+
+    if (toggle && overflowMenu) {
+      if (!overflowMenu.id) {
+        overflowMenu.id = "site-nav-overflow";
+      }
+
+      toggle.setAttribute("aria-controls", overflowMenu.id);
+
+      var updateExpandedState = function () {
+        toggle.setAttribute("aria-expanded", toggle.classList.contains("close") ? "true" : "false");
+      };
+
+      updateExpandedState();
+      new MutationObserver(updateExpandedState).observe(toggle, {
+        attributes: true,
+        attributeFilter: ["class"]
+      });
+    }
+
+    var currentPath = normalizePath(window.location.pathname);
+    document.querySelectorAll(".greedy-nav a[href]").forEach(function (link) {
+      var linkPath = normalizePath(new URL(link.href, window.location.origin).pathname);
+      if (linkPath === currentPath) {
+        link.setAttribute("aria-current", "page");
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeNavigationAccessibility);
+  } else {
+    initializeNavigationAccessibility();
+  }
+})();

--- a/assets/javascript/publication-browser.js
+++ b/assets/javascript/publication-browser.js
@@ -1,0 +1,123 @@
+(function () {
+  "use strict";
+
+  const browser = document.querySelector("[data-publication-browser]");
+
+  if (!browser) {
+    return;
+  }
+
+  const list = browser.querySelector("[data-publication-list]");
+  const queryInput = browser.querySelector("[data-publication-query]");
+  const typeSelect = browser.querySelector("[data-publication-type]");
+  const yearSelect = browser.querySelector("[data-publication-year]");
+  const sortSelect = browser.querySelector("[data-publication-sort]");
+  const resetButton = browser.querySelector("[data-publication-reset]");
+  const status = browser.querySelector("[data-publication-status]");
+  const empty = browser.querySelector("[data-publication-empty]");
+  const collator = new Intl.Collator("en", { sensitivity: "base" });
+
+  if (!list || !queryInput || !typeSelect || !yearSelect || !sortSelect || !resetButton || !status || !empty) {
+    return;
+  }
+
+  function normalize(value) {
+    return String(value || "")
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, " ")
+      .trim();
+  }
+
+  const entries = Array.from(list.querySelectorAll("[data-publication-entry]")).map(function (element) {
+    return {
+      element: element,
+      index: Number(element.dataset.publicationIndex),
+      search: normalize(element.dataset.publicationSearch),
+      title: normalize(element.dataset.publicationTitle),
+      type: element.dataset.publicationType,
+      year: Number(element.dataset.publicationYear)
+    };
+  });
+
+  const years = Array.from(new Set(entries.map(function (entry) {
+    return entry.year;
+  }).filter(Number.isFinite))).sort(function (a, b) {
+    return b - a;
+  });
+
+  years.forEach(function (year) {
+    const option = document.createElement("option");
+    option.value = String(year);
+    option.textContent = String(year);
+    yearSelect.append(option);
+  });
+
+  function compareEntries(a, b) {
+    let result = 0;
+
+    if (sortSelect.value === "oldest") {
+      result = a.year - b.year;
+    } else if (sortSelect.value === "title") {
+      result = collator.compare(a.title, b.title);
+      if (result === 0) {
+        result = b.year - a.year;
+      }
+    } else {
+      result = b.year - a.year;
+    }
+
+    if (result === 0) {
+      result = collator.compare(a.title, b.title);
+    }
+
+    if (result === 0) {
+      result = a.index - b.index;
+    }
+
+    return result;
+  }
+
+  function updatePublications() {
+    const queryTerms = normalize(queryInput.value).split(/\s+/).filter(Boolean);
+    const selectedType = typeSelect.value;
+    const selectedYear = yearSelect.value;
+    const sortedEntries = entries.slice().sort(compareEntries);
+    const fragment = document.createDocumentFragment();
+    let visibleCount = 0;
+
+    sortedEntries.forEach(function (entry) {
+      const matchesQuery = queryTerms.every(function (term) {
+        return entry.search.includes(term);
+      });
+      const matchesType = selectedType === "all" || entry.type === selectedType;
+      const matchesYear = selectedYear === "all" || entry.year === Number(selectedYear);
+      const isVisible = matchesQuery && matchesType && matchesYear;
+
+      entry.element.hidden = !isVisible;
+      visibleCount += isVisible ? 1 : 0;
+      fragment.append(entry.element);
+    });
+
+    list.append(fragment);
+    list.hidden = visibleCount === 0;
+    empty.hidden = visibleCount !== 0;
+    status.textContent = "Showing " + visibleCount + " of " + entries.length + " publications.";
+  }
+
+  queryInput.addEventListener("input", updatePublications);
+  typeSelect.addEventListener("change", updatePublications);
+  yearSelect.addEventListener("change", updatePublications);
+  sortSelect.addEventListener("change", updatePublications);
+  resetButton.addEventListener("click", function () {
+    queryInput.value = "";
+    typeSelect.value = "all";
+    yearSelect.value = "all";
+    sortSelect.value = "newest";
+    updatePublications();
+    queryInput.focus();
+  });
+
+  updatePublications();
+}());

--- a/index.md
+++ b/index.md
@@ -1,12 +1,11 @@
 ---
 layout: splash
-classes: wide
+classes: wide solid-hero
 permalink: /
 header:
   og_image: "/assets/social-card.png"
   og_image_alt: "Carnegie Mellon University Design Research Collective"
-  overlay_filter: linear-gradient(rgba(0, 0, 0, 0.5), rgba(234, 133, 52, 0.5))
-  overlay_image: "https://images.unsplash.com/photo-1596213812143-ff89bd9ddecd?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1450&q=80"
+  overlay_color: "#1e3f3e"
   actions:
     - label: "<i class=\"fas fa-users\"></i>   Meet Our Team"
       url: "/team/"
@@ -14,7 +13,6 @@ header:
       url: "mailto:ccm@cmu.edu?subject=Interested in Joining the Design Research Collective"
     - label: "<i class=\"fas fa-book-reader\"></i>   Read Our Work"
       url: "/publications/"
-  caption: "[**Mika Baumeister**](https://unsplash.com/@mbaumi) on [*Unsplash*](https://unsplash.com)"
 research_intro:
   - title: Research Areas
   - excerpt: 'In the Design Research Collective, we explore research at the intersection of engineering design, psychology, and computer science to create superpowers for designers, engineers, and problem-solvers.'


### PR DESCRIPTION
## Summary
- add a live, searchable GitHub and Hugging Face catalog for software, datasets, models, and Spaces
- replace the publication sections with a complete searchable and sortable browser
- refresh the current team and CV-backed alumni directory, including LinkedIn links for all current members
- add a streamlined Join page and updated navigation
- simplify page heroes and improve navigation and color-contrast accessibility

## Validation
- Jekyll production-equivalent build
- axe checks on Home, Team, Publications, Tools & Data, and Join: zero issues
- offline internal-link check: zero errors
- JavaScript syntax and YAML integrity checks
- independent final diff review: no release blockers